### PR TITLE
Add ThumbnailUrl property to ReleaseArtist class

### DIFF
--- a/src/DiscogsApiClient.Tests/Collection/WantlistTestFixture.cs
+++ b/src/DiscogsApiClient.Tests/Collection/WantlistTestFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace DiscogsApiClient.Tests.Collection;
+namespace DiscogsApiClient.Tests.Collection;
 
 public sealed class WantlistTestFixture : ApiBaseTestFixture
 {
@@ -167,6 +167,7 @@ public sealed class WantlistTestFixture : ApiBaseTestFixture
         Assert.AreEqual(287459, addedRelease.Release.Artists[0].Id);
         Assert.AreEqual("HammerFall", addedRelease.Release.Artists[0].Name);
         Assert.IsFalse(string.IsNullOrWhiteSpace(addedRelease.Release.Artists[0].ResourceUrl));
+        Assert.DoesNotThrow(() => new Uri(addedRelease.Release.Artists[0].ThumbnailUrl));
         Assert.IsNotNull(addedRelease.Release.Formats);
         Assert.Less(0, addedRelease.Release.Formats.Count);
         Assert.Less("0", addedRelease.Release.Formats[0].Count);

--- a/src/DiscogsApiClient.Tests/Database/MasterReleaseTestFixture.cs
+++ b/src/DiscogsApiClient.Tests/Database/MasterReleaseTestFixture.cs
@@ -1,4 +1,4 @@
-﻿using static DiscogsApiClient.QueryParameters.MasterReleaseVersionFilterQueryParameters;
+using static DiscogsApiClient.QueryParameters.MasterReleaseVersionFilterQueryParameters;
 
 namespace DiscogsApiClient.Tests.Database;
 
@@ -58,6 +58,7 @@ public sealed class MasterReleaseTestFixture : ApiBaseTestFixture
         Assert.AreEqual(287459, masterRelease.Artists[0].Id);
         Assert.AreEqual("HammerFall", masterRelease.Artists[0].Name);
         Assert.DoesNotThrow(() => new Uri(masterRelease.Artists[0].ResourceUrl));
+        Assert.DoesNotThrow(() => new Uri(masterRelease.Artists[0].ThumbnailUrl));
 
         Assert.Less(0, masterRelease.Videos.Count);
         foreach (var video in masterRelease.Videos)

--- a/src/DiscogsApiClient.Tests/Database/ReleasesTestFixture.cs
+++ b/src/DiscogsApiClient.Tests/Database/ReleasesTestFixture.cs
@@ -1,4 +1,4 @@
-﻿namespace DiscogsApiClient.Tests.Database;
+namespace DiscogsApiClient.Tests.Database;
 
 public sealed class ReleasesTestFixture : ApiBaseTestFixture
 {
@@ -18,6 +18,7 @@ public sealed class ReleasesTestFixture : ApiBaseTestFixture
 
         Assert.AreEqual(1, release.Artists.Count);
         Assert.AreEqual("HammerFall", release.Artists[0].Name);
+        Assert.DoesNotThrow(() => new Uri(release.Artists[0].ThumbnailUrl));
 
         Assert.AreEqual(1, release.Labels.Count);
         Assert.AreEqual(11499, release.Labels[0].Id);

--- a/src/DiscogsApiClient/Contract/Release/ReleaseArtist.cs
+++ b/src/DiscogsApiClient/Contract/Release/ReleaseArtist.cs
@@ -1,4 +1,4 @@
-﻿namespace DiscogsApiClient.Contract.Release;
+namespace DiscogsApiClient.Contract.Release;
 
 /// <summary>
 /// Artist information for a release
@@ -10,6 +10,7 @@
 /// <param name="Join"></param>
 /// <param name="Role"></param>
 /// <param name="Tracks">The tracks this artist participated in on the release</param>
+/// <param name="ThumbnailUrl">The thumbnail image URL for this artist</param>
 public sealed record ReleaseArtist(
     [property:JsonPropertyName("id")]
     int Id,
@@ -24,7 +25,9 @@ public sealed record ReleaseArtist(
     [property:JsonPropertyName("role")]
     string Role,
     [property:JsonPropertyName("tracks")]
-    string Tracks);
+    string Tracks,
+    [property:JsonPropertyName("thumbnail_url")]
+    string ThumbnailUrl);
 
 
 /**


### PR DESCRIPTION
## Description
This PR adds the missing `ThumbnailUrl` property to the `ReleaseArtist` class as requested in issue #4.

## Changes Made
- ✅ Added `ThumbnailUrl` property to `ReleaseArtist` record with `[JsonPropertyName("thumbnail_url")]` attribute
- ✅ Added XML documentation for the new property
- ✅ Updated `ReleasesTestFixture` to verify `ThumbnailUrl` is a valid URI
- ✅ Updated `MasterReleaseTestFixture` to verify `ThumbnailUrl` is a valid URI  
- ✅ Updated `WantlistTestFixture` to verify `ThumbnailUrl` is a valid URI

## Models Affected
The `ReleaseArtist` class is used by:
- `Release`
- `MasterRelease`
- `UserListReleaseInformation` (used in Wantlist and Collection)

All tests for these models have been updated to verify the new property.

## Testing
- ✅ All builds compile successfully
- ✅ Test assertions added for all models using `ReleaseArtist`
- ✅ Follows existing code patterns and conventions

Fixes #4