### PR TITLE
Fix year and released property mappings in Release models

### DIFF
--- a/src/DiscogsApiClient.Tests/Database/MasterReleaseTestFixture.cs
+++ b/src/DiscogsApiClient.Tests/Database/MasterReleaseTestFixture.cs
@@ -112,7 +112,7 @@ public sealed class MasterReleaseTestFixture : ApiBaseTestFixture
         Assert.IsFalse(string.IsNullOrWhiteSpace(version.Title));
         Assert.IsFalse(string.IsNullOrWhiteSpace(version.Format));
         Assert.IsFalse(string.IsNullOrWhiteSpace(version.CatalogNumber));
-        Assert.IsFalse(string.IsNullOrWhiteSpace(version.Year));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(version.Released));
         Assert.IsFalse(string.IsNullOrWhiteSpace(version.Status));
         Assert.DoesNotThrow(() => new Uri(version.ResourceUrl));
         Assert.DoesNotThrow(() => new Uri(version.ThumbnailUrl));
@@ -255,10 +255,10 @@ public sealed class MasterReleaseTestFixture : ApiBaseTestFixture
         var responseDescending = await ApiClient.GetMasterReleaseVersions(masterReleaseId, null, sortParametersDescending);
 
         Assert.That(
-            responseAscending.ReleaseVersions.Select(r => r.Year),
+            responseAscending.ReleaseVersions.Select(r => r.Released),
             Is.Ordered.Ascending);
         Assert.That(
-            responseDescending.ReleaseVersions.Select(r => r.Year),
+            responseDescending.ReleaseVersions.Select(r => r.Released),
             Is.Ordered.Descending);
 
         // Title

--- a/src/DiscogsApiClient.Tests/Database/ReleasesTestFixture.cs
+++ b/src/DiscogsApiClient.Tests/Database/ReleasesTestFixture.cs
@@ -33,9 +33,10 @@ public sealed class ReleasesTestFixture : ApiBaseTestFixture
         Assert.DoesNotThrow(() => new Uri(release.MasterUrl));
         Assert.AreEqual("Glory To The Brave", release.Title);
         Assert.AreEqual("Germany", release.Country);
-        Assert.AreEqual("1997", release.Year);
+        Assert.AreEqual(1997, release.Year);
+        Assert.AreEqual("1997", release.Released);
         Assert.IsFalse(string.IsNullOrWhiteSpace(release.Notes));
-        Assert.AreEqual("1997", release.YearFormatted);
+        Assert.AreEqual("1997", release.ReleasedFormatted);
         Assert.DoesNotThrow(() => new Uri(release.ThumbnailUrl));
         Assert.Less(0, release.EstimatedWeight);
         Assert.IsFalse(release.IsBlockedFromSale);

--- a/src/DiscogsApiClient/Contract/Release/MasterReleaseVersion.cs
+++ b/src/DiscogsApiClient/Contract/Release/MasterReleaseVersion.cs
@@ -31,7 +31,7 @@ public sealed record MasterReleaseVersion(
     [property:JsonPropertyName("catno")]
     string CatalogNumber,
     [property:JsonPropertyName("released")]
-    string Released,
+    string? Released,
     [property:JsonPropertyName("status")]
     string Status,
     [property:JsonPropertyName("resource_url")]

--- a/src/DiscogsApiClient/Contract/Release/MasterReleaseVersion.cs
+++ b/src/DiscogsApiClient/Contract/Release/MasterReleaseVersion.cs
@@ -1,4 +1,4 @@
-﻿namespace DiscogsApiClient.Contract.Release;
+namespace DiscogsApiClient.Contract.Release;
 
 /// <summary>
 /// A specific version of a master release
@@ -10,7 +10,7 @@
 /// <param name="MajorFormats">List of the major physical formats this release is published in</param>
 /// <param name="Format">The format of the release (or type)</param>
 /// <param name="CatalogNumber">The release's catalog number</param>
-/// <param name="Year">release year</param>
+/// <param name="Released">Release date</param>
 /// <param name="Status"></param>
 /// <param name="ResourceUrl">The Api url for this release</param>
 /// <param name="ThumbnailUrl">Thumbnail image url</param>
@@ -31,7 +31,7 @@ public sealed record MasterReleaseVersion(
     [property:JsonPropertyName("catno")]
     string CatalogNumber,
     [property:JsonPropertyName("released")]
-    string Year,
+    string Released,
     [property:JsonPropertyName("status")]
     string Status,
     [property:JsonPropertyName("resource_url")]

--- a/src/DiscogsApiClient/Contract/Release/Release.cs
+++ b/src/DiscogsApiClient/Contract/Release/Release.cs
@@ -73,11 +73,11 @@ public sealed record Release(
     [property:JsonPropertyName("year")]
     int Year,
     [property:JsonPropertyName("released")]
-    string Released,
+    string? Released,
     [property:JsonPropertyName("notes")]
     string Notes,
     [property:JsonPropertyName("released_formatted")]
-    string ReleasedFormatted,
+    string? ReleasedFormatted,
     [property:JsonPropertyName("identifiers")]
     List<ReleaseIdentifier> Identifiers,
     [property:JsonPropertyName("videos")]

--- a/src/DiscogsApiClient/Contract/Release/Release.cs
+++ b/src/DiscogsApiClient/Contract/Release/Release.cs
@@ -1,4 +1,4 @@
-﻿namespace DiscogsApiClient.Contract.Release;
+namespace DiscogsApiClient.Contract.Release;
 
 /// <summary>
 /// Represents a release in the Discogs database
@@ -21,8 +21,9 @@
 /// <param name="Title">Release title</param>
 /// <param name="Country">Release country</param>
 /// <param name="Year">Release year</param>
+/// <param name="Released">Release date</param>
 /// <param name="Notes">Notes for this release</param>
-/// <param name="YearFormatted">Formatted release year</param>
+/// <param name="ReleasedFormatted">Formatted release date</param>
 /// <param name="Identifiers">List of identifiers</param>
 /// <param name="Videos">List of related videos</param>
 /// <param name="Genres">List of genres</param>
@@ -69,12 +70,14 @@ public sealed record Release(
     string Title,
     [property:JsonPropertyName("country")]
     string Country,
+    [property:JsonPropertyName("year")]
+    int Year,
     [property:JsonPropertyName("released")]
-    string Year,
+    string Released,
     [property:JsonPropertyName("notes")]
     string Notes,
     [property:JsonPropertyName("released_formatted")]
-    string YearFormatted,
+    string ReleasedFormatted,
     [property:JsonPropertyName("identifiers")]
     List<ReleaseIdentifier> Identifiers,
     [property:JsonPropertyName("videos")]


### PR DESCRIPTION
## Description
This PR fixes the property mapping mismatch between `year` and `released` fields in Release models as reported in issue #5.

## Changes Made

### 1. Release.cs
- ✅ Added `Year` property (int) correctly mapped to JSON field `"year"`
- ✅ Added `Released` property (string?) correctly mapped to JSON field `"released"`
- ✅ Renamed `YearFormatted` to `ReleasedFormatted` (string?) mapped to JSON field `"released_formatted"`
- ✅ Made `Released` and `ReleasedFormatted` nullable to accurately represent optional API fields

### 2. MasterReleaseVersion.cs
- ✅ Renamed `Year` property to `Released` to match the actual JSON field `"released"`
- ✅ Made `Released` nullable (string?) to accurately represent optional API field

### 3. Tests Updated
- ✅ `ReleasesTestFixture.cs` - Updated to verify `Year` (int), `Released` (string?), and `ReleasedFormatted` (string?)
- ✅ `MasterReleaseTestFixture.cs` - Updated to verify `Released` property

### 4. Models Verified (No Changes Needed)
- ✅ `MasterRelease.cs` - Already correctly maps `year` as int
- ✅ `UserListReleaseInformation.cs` - Already correctly maps `year` as int
- ✅ `ArtistRelease.cs` - Already correctly maps `year` as int

## Property Consistency

All release models now correctly and consistently map their year/released properties:

| Model | year (int) | released (string?) | released_formatted (string?) |
|-------|-----------|-------------------|----------------------------|
| Release | ✅ Yes | ✅ Yes | ✅ Yes (ReleasedFormatted) |
| MasterRelease | ✅ Yes | N/A | N/A |
| MasterReleaseVersion | N/A | ✅ Yes | N/A |
| UserListReleaseInformation | ✅ Yes | N/A | N/A |
| ArtistRelease | ✅ Yes | N/A | N/A |

## Design Decisions
- Made optional string properties nullable (`string?`) following best practices with nullable reference types
- This accurately represents the API contract where these fields may be absent
- Consumers can handle null cases appropriately with null-coalescing operators

Fixes #5