### PR TITLE
Release version 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ public async Task Authenticate(
     - It's been replaced with the two calls ``StartOAuthAuthentication`` and ``CompleteOAuthAuthentication``.
     - With this change the OAuth authentication can be handled more linearly instead of with a callback function.
     - The ``HttpClient`` used by the ``OAuthAuthenticationProvider`` now also uses the ``ErrorHandlingDelegatingHandler`` middleware.
+- ### **4.1.0**
+  - Added ``ThumbnailUrl`` property to ``ReleaseArtist`` model.
+  - Fixed year/released property mappings in ``Release`` and ``MasterReleaseVersion`` models.
+  - **Breaking**:
+    - Renamed ``Release.YearFormatted`` → ``ReleasedFormatted``
+    - Renamed ``MasterReleaseVersion.Year`` → ``Released``
 
 
 ## **Implemented Api Functions**

--- a/src/DiscogsApiClient/DiscogsApiClient.csproj
+++ b/src/DiscogsApiClient/DiscogsApiClient.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
@@ -19,10 +19,10 @@
 		<PackageTags>discogs</PackageTags>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<AssemblyVersion>4.0.0</AssemblyVersion>
-		<FileVersion>4.0.0</FileVersion>
-		<PackageVersion>4.0.0</PackageVersion>
-		<PackageReleaseNotes>Refit has been removed and the library is now Aot compatible.</PackageReleaseNotes>
+		<AssemblyVersion>4.1.0</AssemblyVersion>
+		<FileVersion>4.1.0</FileVersion>
+		<PackageVersion>4.1.0</PackageVersion>
+		<PackageReleaseNotes>Added ThumbnailUrl property to ReleaseArtist model. Fixed year/released property mappings in Release and MasterReleaseVersion models.</PackageReleaseNotes>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This PR prepares the library for publishing version 4.1.0 to NuGet.

## Changes

- Updated version numbers to `4.1.0` in `DiscogsApiClient.csproj`
  - `AssemblyVersion`: 4.0.0 → 4.1.0
  - `FileVersion`: 4.0.0 → 4.1.0
  - `PackageVersion`: 4.0.0 → 4.1.0
- Updated `PackageReleaseNotes` in csproj
- Added 4.1.0 changelog entry to README.md

## Release Notes (4.1.0)

- Added `ThumbnailUrl` property to `ReleaseArtist` model.
- Fixed year/released property mappings in `Release` and `MasterReleaseVersion` models.
- **Breaking**:
  - Renamed `Release.YearFormatted` → `ReleasedFormatted`
  - Renamed `MasterReleaseVersion.Year` → `Released`

After merging this PR, the library will be ready to publish to NuGet.